### PR TITLE
[add] api required private key

### DIFF
--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import routerQuest from './router-quest';
 import routerNotice from './router-notice';
 import routerGuild from './router-guild';
 import routerGuildQuest from './router-guild-quest';
+import routerSystem from './router-system';
 
 // Export the base-router
 const baseRouter = Router();
@@ -14,6 +15,7 @@ baseRouter.use(routerQuest);
 baseRouter.use(routerNotice);
 baseRouter.use(routerGuild);
 baseRouter.use(routerGuildQuest);
+baseRouter.use(routerSystem);
 
 // Export default.
 export default baseRouter;

--- a/backend/src/routes/router-system.ts
+++ b/backend/src/routes/router-system.ts
@@ -1,0 +1,33 @@
+import StatusCodes from 'http-status-codes';
+import { Request, Response, Router } from 'express';
+import {
+  CosignatureSignedTransaction,
+  SignedTransaction,
+} from 'symbol-sdk';
+import { System ,VerifiedSss } from '../services/System';
+
+// Constants
+const router = Router();
+const { OK } = StatusCodes;
+
+// Paths
+export const p = {
+  cosig_system: '/cosig',
+  verify_token: '/verify-token',
+} as const;
+
+/** Cosignate Transaction by System. */
+router.post(p.cosig_system, (req: Request<SignedTransaction>, res: Response<CosignatureSignedTransaction>) => {
+  const { signedTransaction } = req.body;
+  res.status(OK);
+  res.send(System.cosignateBySystem(signedTransaction));
+});
+
+/** Verify ActiveAccountToken from SSS. */
+router.post(p.verify_token, (req: Request<string>, res: Response<VerifiedSss>) => {
+  const { userPublicKey, token, network } = req.body;
+  res.status(OK);
+  res.send(System.verifyToken(userPublicKey, token, network));
+});
+
+export default router;

--- a/backend/src/services/System.ts
+++ b/backend/src/services/System.ts
@@ -1,0 +1,79 @@
+import {
+  CosignatureTransaction,
+  CosignatureSignedTransaction,
+  SignedTransaction,
+  AggregateTransaction,
+  TransferTransaction,
+  Account, 
+  NetworkType,
+  PublicAccount,
+  EncryptedMessage
+} from 'symbol-sdk';
+
+export type VerifiedSss = {
+  signerAddress: string;
+  iat: number;
+  verifierAddress: string;
+  netWork: number;
+};
+
+export class System {
+  static cosignateBySystem(signedTransaction: SignedTransaction): CosignatureSignedTransaction {
+    try {
+      const verify = this.verifyTransaction(signedTransaction);
+      if(!verify) throw new Error('不正なトランザクションの可能性があります')
+      const systemAccount = Account.createFromPrivateKey(process.env.SYSTEM_PRIVATEKEY!, signedTransaction.networkType);
+      const cosignedSignedTransaction = CosignatureTransaction.signTransactionPayload(
+        systemAccount,
+        signedTransaction.payload,
+        process.env.GENERATION_HASH!,
+      );
+      return cosignedSignedTransaction;
+    } catch (e) {
+      throw new Error((e as Error).stack);
+    }
+  }
+  // 正しいトランザクションか検証する。もっとちゃんとしたほうがいいけどとりあえず。
+  protected static verifyTransaction(signedTransaction: SignedTransaction){
+    const aggregateTransaction = AggregateTransaction.createFromPayload(signedTransaction.payload);
+    const transferTransactions = aggregateTransaction.innerTransactions.filter((tx)=>{
+      return tx.type == 16724 && tx.signer?.publicKey == process.env.SYSTEM_PUBLICKEY
+    })
+    const mosaicAmounts = transferTransactions.filter((tx)=>{
+      (tx as TransferTransaction).mosaics.filter((m)=>{
+        return m.amount.compact() > 1
+      })
+    })
+    if(mosaicAmounts.length > 1) return false;
+    return true;
+  }
+
+  /**
+   * 渡されたTokenをSystemアカウントにより復号し、署名が行えるか確認する
+   */
+  static verifyToken(
+    userPublicKey: string,
+    token: string,
+    network: NetworkType,
+  ): VerifiedSss {
+    try {
+      const userPublic = PublicAccount.createFromPublicKey(
+        userPublicKey,
+        network,
+      );
+      const msg = new EncryptedMessage(token, userPublic);
+      const verifier = Account.createFromPrivateKey(
+        process.env.SYSTEM_PRIVATEKEY!,
+        network,
+      );
+      return JSON.parse(
+        verifier.decryptMessage(
+          msg,
+          PublicAccount.createFromPublicKey(userPublicKey, network),
+        ).payload,
+      ) as VerifiedSss;
+    } catch {
+      throw new Error('署名検証に失敗しました');
+    }
+  }
+}


### PR DESCRIPTION
システムの秘密鍵が必要なものをAPIとしました
１．SSSで取得したトークンをシステムの秘密鍵で復号し正しいか検証する
２．Quest完了時のトランザクションにシステムの自動署名を行う